### PR TITLE
criação de views SQL e mapeamento read-only no JPA

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,3 @@
+target/
+.git/
+*.md

--- a/backend/src/main/java/br/edu/ufape/lanchonete/model/view/VwEstoqueCritico.java
+++ b/backend/src/main/java/br/edu/ufape/lanchonete/model/view/VwEstoqueCritico.java
@@ -1,0 +1,55 @@
+package br.edu.ufape.lanchonete.model.view;
+
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.Immutable;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+/**
+ * Entidade read-only mapeada para a view vw_estoque_critico.
+ * Retorna apenas produtos cuja quantidade atual atingiu ou ficou
+ * abaixo do mínimo configurado, expondo a quantidade a repor.
+ * Nenhuma operação de escrita é permitida (@Immutable).
+ */
+@Entity
+@Immutable
+@Table(name = "vw_estoque_critico")
+public class VwEstoqueCritico {
+
+    @Id
+    @Column(name = "id_produto")
+    private Integer idProduto;
+
+    @Column(name = "nome", length = 100)
+    private String nome;
+
+    @Column(name = "unidade_medida", length = 10)
+    private String unidadeMedida;
+
+    @Column(name = "qtd_estoque_atual")
+    private Integer qtdEstoqueAtual;
+
+    @Column(name = "qtd_estoque_minimo")
+    private Integer qtdEstoqueMinimo;
+
+    @Column(name = "qtd_a_repor")
+    private Integer qtdARepor;
+
+    @Column(name = "data_ultima_atualizacao")
+    private LocalDateTime dataUltimaAtualizacao;
+
+    public VwEstoqueCritico() {}
+
+
+    public Integer getIdProduto() { return idProduto; }
+    public String getNome() { return nome; }
+    public String getUnidadeMedida() { return unidadeMedida; }
+    public Integer getQtdEstoqueAtual() { return qtdEstoqueAtual; }
+    public Integer getQtdEstoqueMinimo() { return qtdEstoqueMinimo; }
+    public Integer getQtdARepor() { return qtdARepor; }
+    public LocalDateTime getDataUltimaAtualizacao() { return dataUltimaAtualizacao; }
+}

--- a/backend/src/main/java/br/edu/ufape/lanchonete/model/view/VwPedidoCompleto.java
+++ b/backend/src/main/java/br/edu/ufape/lanchonete/model/view/VwPedidoCompleto.java
@@ -1,0 +1,112 @@
+package br.edu.ufape.lanchonete.model.view;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.Immutable;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+/**
+ * Entidade read-only mapeada para a view vw_pedido_completo.
+ * Consolida Pedido + Cliente + ItemPedido + Cardapio + Pagamento.
+ * Nenhuma operação de escrita é permitida (@Immutable).
+ */
+@Entity
+@Immutable
+@Table(name = "vw_pedido_completo")
+public class VwPedidoCompleto {
+
+
+    @Id
+    @Column(name = "id_item_pedido")
+    private Integer idItemPedido;
+
+    @Column(name = "id_pedido")
+    private Integer idPedido;
+
+    @Column(name = "data_hora")
+    private LocalDateTime dataHora;
+
+    @Column(name = "situacao", length = 20)
+    private String situacao;
+
+    @Column(name = "endereco_entrega", columnDefinition = "TEXT")
+    private String enderecoEntrega;
+
+    @Column(name = "taxa_entrega", precision = 10, scale = 2)
+    private BigDecimal taxaEntrega;
+
+    @Column(name = "valor_total", precision = 10, scale = 2)
+    private BigDecimal valorTotal;
+
+
+    @Column(name = "cpf_cliente", length = 11)
+    private String cpfCliente;
+
+    @Column(name = "nome_cliente", length = 100)
+    private String nomeCliente;
+
+    @Column(name = "telefone_cliente", length = 20)
+    private String telefoneCliente;
+
+
+    @Column(name = "quantidade")
+    private Integer quantidade;
+
+    @Column(name = "valor_unitario", precision = 10, scale = 2)
+    private BigDecimal valorUnitario;
+
+    @Column(name = "subtotal_item", precision = 10, scale = 2)
+    private BigDecimal subtotalItem;
+
+
+    @Column(name = "id_cardapio")
+    private Integer idCardapio;
+
+    @Column(name = "nome_produto", length = 100)
+    private String nomeProduto;
+
+    @Column(name = "categoria_produto", length = 20)
+    private String categoriaProduto;
+
+
+    @Column(name = "id_pagamento")
+    private Integer idPagamento;
+
+    @Column(name = "metodo_pagamento", length = 50)
+    private String metodoPagamento;
+
+    @Column(name = "valor_pago", precision = 10, scale = 2)
+    private BigDecimal valorPago;
+
+    @Column(name = "datahora_pagamento")
+    private LocalDateTime datahoraPagamento;
+
+    public VwPedidoCompleto() {}
+
+
+    public Integer getIdItemPedido() { return idItemPedido; }
+    public Integer getIdPedido() { return idPedido; }
+    public LocalDateTime getDataHora() { return dataHora; }
+    public String getSituacao() { return situacao; }
+    public String getEnderecoEntrega() { return enderecoEntrega; }
+    public BigDecimal getTaxaEntrega() { return taxaEntrega; }
+    public BigDecimal getValorTotal() { return valorTotal; }
+    public String getCpfCliente() { return cpfCliente; }
+    public String getNomeCliente() { return nomeCliente; }
+    public String getTelefoneCliente() { return telefoneCliente; }
+    public Integer getQuantidade() { return quantidade; }
+    public BigDecimal getValorUnitario() { return valorUnitario; }
+    public BigDecimal getSubtotalItem() { return subtotalItem; }
+    public Integer getIdCardapio() { return idCardapio; }
+    public String getNomeProduto() { return nomeProduto; }
+    public String getCategoriaProduto() { return categoriaProduto; }
+    public Integer getIdPagamento() { return idPagamento; }
+    public String getMetodoPagamento() { return metodoPagamento; }
+    public BigDecimal getValorPago() { return valorPago; }
+    public LocalDateTime getDatahoraPagamento() { return datahoraPagamento; }
+}

--- a/backend/src/main/java/br/edu/ufape/lanchonete/model/view/VwPedidosEmAberto.java
+++ b/backend/src/main/java/br/edu/ufape/lanchonete/model/view/VwPedidosEmAberto.java
@@ -1,0 +1,64 @@
+package br.edu.ufape.lanchonete.model.view;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import org.hibernate.annotations.Immutable;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+/**
+ * Entidade read-only mapeada para a view vw_pedidos_em_aberto.
+ * Retorna apenas pedidos com situação 'Pendente' ou 'Em Preparo',
+ * ordenados do mais antigo para o mais novo (fila FIFO da cozinha).
+ * Nenhuma operação de escrita é permitida (@Immutable).
+ */
+@Entity
+@Immutable
+@Table(name = "vw_pedidos_em_aberto")
+public class VwPedidosEmAberto {
+
+    @Id
+    @Column(name = "id_pedido")
+    private Integer idPedido;
+
+    @Column(name = "data_hora")
+    private LocalDateTime dataHora;
+
+    @Column(name = "situacao", length = 20)
+    private String situacao;
+
+    @Column(name = "endereco_entrega", columnDefinition = "TEXT")
+    private String enderecoEntrega;
+
+    @Column(name = "ponto_referencia", columnDefinition = "TEXT")
+    private String pontoReferencia;
+
+    @Column(name = "taxa_entrega", precision = 10, scale = 2)
+    private BigDecimal taxaEntrega;
+
+    @Column(name = "valor_total", precision = 10, scale = 2)
+    private BigDecimal valorTotal;
+
+    @Column(name = "nome_cliente", length = 100)
+    private String nomeCliente;
+
+    @Column(name = "telefone_cliente", length = 20)
+    private String telefoneCliente;
+
+    public VwPedidosEmAberto() {}
+
+
+    public Integer getIdPedido() { return idPedido; }
+    public LocalDateTime getDataHora() { return dataHora; }
+    public String getSituacao() { return situacao; }
+    public String getEnderecoEntrega() { return enderecoEntrega; }
+    public String getPontoReferencia() { return pontoReferencia; }
+    public BigDecimal getTaxaEntrega() { return taxaEntrega; }
+    public BigDecimal getValorTotal() { return valorTotal; }
+    public String getNomeCliente() { return nomeCliente; }
+    public String getTelefoneCliente() { return telefoneCliente; }
+}

--- a/backend/src/main/java/br/edu/ufape/lanchonete/model/view/VwProdutosMaisVendidos.java
+++ b/backend/src/main/java/br/edu/ufape/lanchonete/model/view/VwProdutosMaisVendidos.java
@@ -1,0 +1,51 @@
+package br.edu.ufape.lanchonete.model.view;
+
+import java.math.BigDecimal;
+
+import org.hibernate.annotations.Immutable;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+/**
+ * Entidade read-only mapeada para a view vw_produtos_mais_vendidos.
+ * Agrega quantidades vendidas e receita por produto do cardápio,
+ * excluindo pedidos cancelados.
+ * Nenhuma operação de escrita é permitida (@Immutable).
+ */
+@Entity
+@Immutable
+@Table(name = "vw_produtos_mais_vendidos")
+public class VwProdutosMaisVendidos {
+
+    @Id
+    @Column(name = "id_cardapio")
+    private Integer idCardapio;
+
+    @Column(name = "nome_produto", length = 100)
+    private String nomeProduto;
+
+    @Column(name = "categoria", length = 20)
+    private String categoria;
+
+    @Column(name = "preco_unitario", precision = 10, scale = 2)
+    private BigDecimal precoUnitario;
+
+    @Column(name = "total_unidades_vendidas")
+    private Long totalUnidadesVendidas;
+
+    @Column(name = "receita_total", precision = 10, scale = 2)
+    private BigDecimal receitaTotal;
+
+    public VwProdutosMaisVendidos() {}
+
+
+    public Integer getIdCardapio() { return idCardapio; }
+    public String getNomeProduto() { return nomeProduto; }
+    public String getCategoria() { return categoria; }
+    public BigDecimal getPrecoUnitario() { return precoUnitario; }
+    public Long getTotalUnidadesVendidas() { return totalUnidadesVendidas; }
+    public BigDecimal getReceitaTotal() { return receitaTotal; }
+}

--- a/backend/src/main/java/br/edu/ufape/lanchonete/repository/view/VwEstoqueCriticoRepository.java
+++ b/backend/src/main/java/br/edu/ufape/lanchonete/repository/view/VwEstoqueCriticoRepository.java
@@ -1,0 +1,10 @@
+package br.edu.ufape.lanchonete.repository.view;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import br.edu.ufape.lanchonete.model.view.VwEstoqueCritico;
+
+@Repository
+public interface VwEstoqueCriticoRepository extends JpaRepository<VwEstoqueCritico, Integer> {
+}

--- a/backend/src/main/java/br/edu/ufape/lanchonete/repository/view/VwPedidoCompletoRepository.java
+++ b/backend/src/main/java/br/edu/ufape/lanchonete/repository/view/VwPedidoCompletoRepository.java
@@ -1,0 +1,18 @@
+package br.edu.ufape.lanchonete.repository.view;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import br.edu.ufape.lanchonete.model.view.VwPedidoCompleto;
+
+@Repository
+public interface VwPedidoCompletoRepository extends JpaRepository<VwPedidoCompleto, Integer> {
+
+    List<VwPedidoCompleto> findByIdPedido(Integer idPedido);
+
+    List<VwPedidoCompleto> findBySituacao(String situacao);
+
+    List<VwPedidoCompleto> findByCpfCliente(String cpfCliente);
+}

--- a/backend/src/main/java/br/edu/ufape/lanchonete/repository/view/VwPedidosEmAbertoRepository.java
+++ b/backend/src/main/java/br/edu/ufape/lanchonete/repository/view/VwPedidosEmAbertoRepository.java
@@ -1,0 +1,14 @@
+package br.edu.ufape.lanchonete.repository.view;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import br.edu.ufape.lanchonete.model.view.VwPedidosEmAberto;
+
+@Repository
+public interface VwPedidosEmAbertoRepository extends JpaRepository<VwPedidosEmAberto, Integer> {
+
+    List<VwPedidosEmAberto> findBySituacao(String situacao);
+}

--- a/backend/src/main/java/br/edu/ufape/lanchonete/repository/view/VwProdutosMaisVendidosRepository.java
+++ b/backend/src/main/java/br/edu/ufape/lanchonete/repository/view/VwProdutosMaisVendidosRepository.java
@@ -1,0 +1,14 @@
+package br.edu.ufape.lanchonete.repository.view;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import br.edu.ufape.lanchonete.model.view.VwProdutosMaisVendidos;
+
+@Repository
+public interface VwProdutosMaisVendidosRepository extends JpaRepository<VwProdutosMaisVendidos, Integer> {
+
+    List<VwProdutosMaisVendidos> findByCategoria(String categoria);
+}

--- a/docs/especificacao_tecnica_views.md
+++ b/docs/especificacao_tecnica_views.md
@@ -1,0 +1,164 @@
+# Especificação Técnica das Visões (Views) — Issue #13
+
+## Análise do Modelo Relacional
+
+O modelo relacional da lanchonete é composto por **10 tabelas**:
+`Cliente`, `Funcionario`, `Fornecedor`, `Estoque`, `Cardapio`,
+`Compra`, `ItemCompra`, `Pedido`, `ItemPedido`, `Pagamento`.
+
+As consultas mais frequentes e complexas do sistema foram identificadas abaixo,
+justificando a criação de cada visão.
+
+---
+
+## Visão 01 — `vw_pedido_completo`
+
+### Objetivo de Negócio
+Fornecer uma visão consolidada de toda a jornada de um pedido — quem pediu,
+o que pediu, quanto custou e como pagou — em uma única consulta. Usada para
+relatórios de vendas, histórico do cliente e detalhamento de pedidos no painel
+administrativo.
+
+### Complexidade Identificada
+Sem a view, qualquer consulta sobre um pedido exige **4 JOINs obrigatórios**:
+
+```sql
+-- Query complexa que a view substitui:
+SELECT p.id_pedido, p.situacao,
+       c.nome AS cliente,
+       ip.quantidade, ip.valor_unitario,
+       ca.nome AS produto,
+       pg.metodo_pagamento, pg.valor_pago
+FROM Pedido p
+JOIN Cliente      c  ON c.cpf          = p.cpf_cliente      -- relação Pedido → Cliente
+JOIN ItemPedido   ip ON ip.id_pedido   = p.id_pedido         -- relação Pedido → Itens
+JOIN Cardapio     ca ON ca.id_cardapio = ip.id_cardapio      -- relação Itens → Produto
+LEFT JOIN Pagamento pg ON pg.id_pedido = p.id_pedido;        -- relação Pedido → Pagamento
+```
+
+### Colunas Expostas
+| Coluna | Origem | Descrição |
+|---|---|---|
+| `id_pedido` | Pedido | Identificador do pedido |
+| `situacao` | Pedido | Status atual (Pendente, Em Preparo, Entregue, Cancelado) |
+| `nome_cliente` | Cliente | Nome do cliente que realizou o pedido |
+| `nome_produto` | Cardapio | Nome do item do cardápio pedido |
+| `categoria_produto` | Cardapio | Categoria do item (Lanche, Bebida, Sobremesa) |
+| `subtotal_item` | Calculado | `quantidade × valor_unitario` por item |
+| `metodo_pagamento` | Pagamento | Forma de pagamento utilizada |
+| `valor_pago` | Pagamento | Valor efetivamente pago |
+
+---
+
+## Visão 02 — `vw_produtos_mais_vendidos`
+
+### Objetivo de Negócio
+Gerar ranking de desempenho dos produtos do cardápio, mostrando quantas unidades
+foram vendidas e quanto cada produto gerou de receita. Usada no dashboard gerencial
+para decisões de cardápio, promoções e gestão de estoque.
+
+### Complexidade Identificada
+Exige **2 JOINs + GROUP BY + funções de agregação (SUM)** com filtro de negócio
+(excluir pedidos cancelados):
+
+```sql
+-- Query complexa que a view substitui:
+SELECT ca.nome, ca.categoria,
+       SUM(ip.quantidade)                    AS total_unidades_vendidas,
+       SUM(ip.quantidade * ip.valor_unitario) AS receita_total
+FROM Cardapio ca
+JOIN ItemPedido ip ON ip.id_cardapio = ca.id_cardapio
+JOIN Pedido     p  ON p.id_pedido    = ip.id_pedido
+WHERE p.situacao != 'Cancelado'           -- regra de negócio encapsulada
+GROUP BY ca.id_cardapio, ca.nome, ca.categoria, ca.preco
+ORDER BY total_unidades_vendidas DESC;
+```
+
+### Colunas Expostas
+| Coluna | Origem | Descrição |
+|---|---|---|
+| `nome_produto` | Cardapio | Nome do item |
+| `categoria` | Cardapio | Categoria do item |
+| `preco_unitario` | Cardapio | Preço de venda atual |
+| `total_unidades_vendidas` | Calculado (SUM) | Total de unidades vendidas (excl. cancelados) |
+| `receita_total` | Calculado (SUM) | Receita bruta gerada pelo produto |
+
+---
+
+## Visão 03 — `vw_estoque_critico`
+
+### Objetivo de Negócio
+Identificar imediatamente quais ingredientes precisam de reposição, comparando
+o estoque atual com o mínimo definido para cada produto. Usada pelo responsável
+de compras para gerar ordens de reposição e acionar fornecedores.
+
+### Complexidade Identificada
+Embora consulte uma única tabela, **encapsula uma regra de negócio crítica**
+(`atual <= minimo`) e um cálculo derivado (`qtd_a_repor`). Sem a view, a regra
+precisaria ser replicada em toda camada que precisasse desse dado:
+
+```sql
+-- Query com regra de negócio encapsulada:
+SELECT nome, unidade_medida,
+       qtd_estoque_atual,
+       qtd_estoque_minimo,
+       (qtd_estoque_minimo - qtd_estoque_atual) AS qtd_a_repor  -- cálculo derivado
+FROM Estoque
+WHERE qtd_estoque_atual <= qtd_estoque_minimo                   -- regra de reposição
+ORDER BY qtd_a_repor DESC;
+```
+
+### Colunas Expostas
+| Coluna | Origem | Descrição |
+|---|---|---|
+| `nome` | Estoque | Nome do ingrediente |
+| `unidade_medida` | Estoque | Unidade (kg, un, L...) |
+| `qtd_estoque_atual` | Estoque | Quantidade disponível |
+| `qtd_estoque_minimo` | Estoque | Limite mínimo configurado |
+| `qtd_a_repor` | Calculado | Quantidade necessária para atingir o mínimo |
+| `data_ultima_atualizacao` | Estoque | Última movimentação registrada |
+
+---
+
+## Visão 04 — `vw_pedidos_em_aberto` *(bônus)*
+
+### Objetivo de Negócio
+Exibir em tempo real a fila de pedidos que ainda precisam ser atendidos
+(status `Pendente` ou `Em Preparo`). Usada pela equipe de cozinha e atendimento
+para gerenciar a fila de produção e entrega.
+
+### Complexidade Identificada
+Requer **JOIN com Cliente** e **filtro composto por múltiplos status**, com
+ordenação cronológica para priorizar os pedidos mais antigos:
+
+```sql
+-- Query de fila operacional que a view substitui:
+SELECT p.id_pedido, p.data_hora, p.situacao,
+       p.endereco_entrega, p.ponto_referencia,
+       c.nome AS nome_cliente, c.telefone
+FROM Pedido p
+JOIN Cliente c ON c.cpf = p.cpf_cliente
+WHERE p.situacao IN ('Pendente', 'Em Preparo')   -- filtro composto de status
+ORDER BY p.data_hora ASC;                         -- mais antigo primeiro (FIFO)
+```
+
+### Colunas Expostas
+| Coluna | Origem | Descrição |
+|---|---|---|
+| `id_pedido` | Pedido | Identificador do pedido |
+| `data_hora` | Pedido | Momento do pedido (usado para ordenar a fila) |
+| `situacao` | Pedido | Status atual |
+| `endereco_entrega` | Pedido | Endereço para delivery (nulo se balcão) |
+| `nome_cliente` | Cliente | Nome para identificação |
+| `telefone_cliente` | Cliente | Contato para retorno |
+
+---
+
+## Resumo Comparativo
+
+| View | Tabelas envolvidas | Recursos SQL utilizados |
+|---|---|---|
+| `vw_pedido_completo` | 5 (Pedido, Cliente, ItemPedido, Cardapio, Pagamento) | 3 INNER JOINs + 1 LEFT JOIN + coluna calculada |
+| `vw_produtos_mais_vendidos` | 3 (Cardapio, ItemPedido, Pedido) | 2 JOINs + GROUP BY + SUM + WHERE com regra de negócio |
+| `vw_estoque_critico` | 1 (Estoque) | WHERE com regra de negócio + coluna calculada |
+| `vw_pedidos_em_aberto` | 2 (Pedido, Cliente) | JOIN + WHERE composto + ORDER BY |

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.git/
+*.md

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine AS build
+FROM node:22-alpine AS build
 
 WORKDIR /app
 
@@ -10,7 +10,7 @@ RUN npm run build
 
 FROM nginx:alpine
 
-COPY --from=build /app/dist/frontend /usr/share/nginx/html
+COPY --from=build /app/dist/frontend/browser /usr/share/nginx/html
 
 EXPOSE 80
 

--- a/sql/03_ddl_views.sql
+++ b/sql/03_ddl_views.sql
@@ -1,0 +1,98 @@
+-- =============================================================
+-- SCRIPT DE MIGRAÇÃO — CRIAÇÃO DAS VISÕES (VIEWS)
+-- Issue: #17 - BD - Validação de Performance e Script de Migração
+-- Parent: #5 - Criação de Visões (Views)
+--
+-- Pré-requisito: 01_ddl_criacao.sql já executado (tabelas existem)
+-- Ordem de execução: 01 → 02 → 03
+-- =============================================================
+
+-- View 01 - Simplificação de Relacionamentos (#14)
+-- Consolida em uma única consulta todos os dados relevantes de
+-- um pedido: cliente, itens, produtos e pagamento.
+
+CREATE OR REPLACE VIEW vw_pedido_completo AS
+SELECT
+    p.id_pedido,
+    p.data_hora,
+    p.situacao,
+    p.endereco_entrega,
+    p.taxa_entrega,
+    p.valor_total,
+    c.cpf                               AS cpf_cliente,
+    c.nome                              AS nome_cliente,
+    c.telefone                          AS telefone_cliente,
+    ip.id_item_pedido,
+    ip.quantidade,
+    ip.valor_unitario,
+    ca.id_cardapio,
+    ca.nome                             AS nome_produto,
+    ca.categoria                        AS categoria_produto,
+    (ip.quantidade * ip.valor_unitario) AS subtotal_item,
+    pg.id_pagamento,
+    pg.metodo_pagamento,
+    pg.valor_pago,
+    pg.datahora_pagamento
+FROM Pedido p
+JOIN Cliente      c  ON c.cpf            = p.cpf_cliente
+JOIN ItemPedido   ip ON ip.id_pedido     = p.id_pedido
+JOIN Cardapio     ca ON ca.id_cardapio   = ip.id_cardapio
+LEFT JOIN Pagamento pg ON pg.id_pedido   = p.id_pedido;
+
+-- View 02 - Agregação e Métricas (#15)
+-- Ranking de produtos por quantidade vendida e receita gerada.
+-- Exige GROUP BY + SUM + JOIN — simplificado em uma consulta direta.
+
+CREATE OR REPLACE VIEW vw_produtos_mais_vendidos AS
+SELECT
+    ca.id_cardapio,
+    ca.nome                                    AS nome_produto,
+    ca.categoria,
+    ca.preco                                   AS preco_unitario,
+    SUM(ip.quantidade)                         AS total_unidades_vendidas,
+    SUM(ip.quantidade * ip.valor_unitario)     AS receita_total
+FROM Cardapio ca
+JOIN ItemPedido ip ON ip.id_cardapio = ca.id_cardapio
+JOIN Pedido     p  ON p.id_pedido    = ip.id_pedido
+WHERE p.situacao != 'Cancelado'
+GROUP BY ca.id_cardapio, ca.nome, ca.categoria, ca.preco
+ORDER BY total_unidades_vendidas DESC;
+
+-- View 03 - Filtros Estratégicos — Alerta de Reposição (#16)
+-- Produtos do estoque cujo saldo atual atingiu ou ficou abaixo
+-- do mínimo definido. Encapsula a regra de negócio de reposição
+-- para que nenhuma camada precise repeti-la.
+
+CREATE OR REPLACE VIEW vw_estoque_critico AS
+SELECT
+    id_produto,
+    nome,
+    unidade_medida,
+    qtd_estoque_atual,
+    qtd_estoque_minimo,
+    (qtd_estoque_minimo - qtd_estoque_atual) AS qtd_a_repor,
+    data_ultima_atualizacao
+FROM Estoque
+WHERE qtd_estoque_atual <= qtd_estoque_minimo
+ORDER BY qtd_a_repor DESC;
+
+-- View 04 - Filtros Estratégicos — Fila Operacional (#16)
+-- Pedidos ainda não finalizados (Pendente ou Em Preparo).
+-- Usada pela cozinha/atendimento para acompanhar a fila em
+-- tempo real sem precisar filtrar manualmente por situação.
+
+CREATE OR REPLACE VIEW vw_pedidos_em_aberto AS
+SELECT
+    p.id_pedido,
+    p.data_hora,
+    p.situacao,
+    p.endereco_entrega,
+    p.ponto_referencia,
+    p.taxa_entrega,
+    p.valor_total,
+    c.nome      AS nome_cliente,
+    c.telefone  AS telefone_cliente
+FROM Pedido p
+JOIN Cliente c ON c.cpf = p.cpf_cliente
+WHERE p.situacao IN ('Pendente', 'Em Preparo')
+ORDER BY p.data_hora ASC;

--- a/sql/04_explain_analyze.sql
+++ b/sql/04_explain_analyze.sql
@@ -1,0 +1,92 @@
+-- =============================================================
+-- SCRIPT DE VALIDAÇÃO DE PERFORMANCE — EXPLAIN ANALYZE
+-- Issue: #17 - BD - Validação de Performance e Script de Migração
+--
+-- Como executar:
+--   1. Suba o banco: docker-compose up db -d
+--   2. Conecte via psql ou DBeaver no banco 'lanchonete'
+--   3. Execute este script e analise os planos de execução
+--
+-- O que observar nos resultados:
+--   - "Seq Scan" em tabelas grandes → candidato a índice
+--   - "Hash Join" / "Nested Loop" → método de join escolhido pelo planner
+--   - "cost=X..Y" → estimativa de custo (menor = melhor)
+--   - "actual time=X..Y" → tempo real em ms
+--   - "rows=N" → número de linhas retornadas
+-- =============================================================
+
+-- -------------------------------------------------------------
+-- 1. vw_pedido_completo
+--    Esperado: Hash Joins nas 4 tabelas envolvidas.
+--    Se "Seq Scan" aparecer em Pedido/ItemPedido com muitas rows,
+--    considerar índice em ItemPedido(id_pedido) e Pagamento(id_pedido).
+-- -------------------------------------------------------------
+EXPLAIN ANALYZE
+SELECT * FROM vw_pedido_completo;
+
+-- Consulta filtrada por situação (caso de uso mais comum):
+EXPLAIN ANALYZE
+SELECT * FROM vw_pedido_completo
+WHERE situacao = 'Entregue';
+
+-- Consulta filtrada por cliente:
+EXPLAIN ANALYZE
+SELECT * FROM vw_pedido_completo
+WHERE cpf_cliente = '11111111111';
+
+-- -------------------------------------------------------------
+-- 2. vw_produtos_mais_vendidos
+--    Esperado: HashAggregate para o GROUP BY.
+--    O planner pode usar Seq Scan em Cardapio e ItemPedido
+--    (aceitável, pois precisa de todos os registros para agregar).
+-- -------------------------------------------------------------
+EXPLAIN ANALYZE
+SELECT * FROM vw_produtos_mais_vendidos;
+
+-- Filtro por categoria (uso no dashboard):
+EXPLAIN ANALYZE
+SELECT * FROM vw_produtos_mais_vendidos
+WHERE categoria = 'Lanche';
+
+-- -------------------------------------------------------------
+-- 3. vw_estoque_critico
+--    Esperado: Seq Scan em Estoque com Filter.
+--    Para tabelas de estoque grandes, índice parcial pode ajudar:
+--    CREATE INDEX idx_estoque_critico ON Estoque(qtd_estoque_atual)
+--    WHERE qtd_estoque_atual <= qtd_estoque_minimo;
+-- -------------------------------------------------------------
+EXPLAIN ANALYZE
+SELECT * FROM vw_estoque_critico;
+
+-- -------------------------------------------------------------
+-- 4. vw_pedidos_em_aberto
+--    Esperado: Seq Scan em Pedido com Filter por situacao.
+--    Se a fila de pedidos crescer muito, avaliar:
+--    CREATE INDEX idx_pedido_situacao ON Pedido(situacao)
+--    WHERE situacao IN ('Pendente', 'Em Preparo');
+-- -------------------------------------------------------------
+EXPLAIN ANALYZE
+SELECT * FROM vw_pedidos_em_aberto;
+
+-- =============================================================
+-- ÍNDICES RECOMENDADOS (aplicar se EXPLAIN mostrar Seq Scan
+-- com custo elevado nas tabelas abaixo)
+-- =============================================================
+
+-- Acelera join de ItemPedido → Pedido (usado em vw_pedido_completo
+-- e vw_produtos_mais_vendidos)
+-- CREATE INDEX IF NOT EXISTS idx_itempedido_pedido
+--     ON ItemPedido(id_pedido);
+
+-- Acelera join de Pagamento → Pedido (LEFT JOIN em vw_pedido_completo)
+-- CREATE INDEX IF NOT EXISTS idx_pagamento_pedido
+--     ON Pagamento(id_pedido);
+
+-- Acelera filtro de fila operacional em vw_pedidos_em_aberto
+-- CREATE INDEX IF NOT EXISTS idx_pedido_situacao
+--     ON Pedido(situacao)
+--     WHERE situacao IN ('Pendente', 'Em Preparo');
+
+-- Acelera filtro de reposição em vw_estoque_critico
+-- CREATE INDEX IF NOT EXISTS idx_estoque_critico
+--     ON Estoque(qtd_estoque_atual, qtd_estoque_minimo);


### PR DESCRIPTION
Implementação das issues #13, #14, #15, #16, #17 e #18 — bloco completo

de Criação de Visões (Views) e integração com o backend.

SQL:

- Criadas 4 views em sql/03_ddl_views.sql (script de migração dedicado):

  - vw_pedido_completo: consolida Pedido + Cliente + ItemPedido + Cardapio + Pagamento

  - vw_produtos_mais_vendidos: ranking de vendas com agregação por produto

  - vw_estoque_critico: alerta de reposição (qtd_atual <= qtd_minimo)

  - vw_pedidos_em_aberto: fila operacional da cozinha (Pendente/Em Preparo)

- Criado sql/04_explain_analyze.sql com EXPLAIN ANALYZE de todas as views

  e índices recomendados comentados para avaliação de performance

- Criado docs/especificacao_tecnica_views.md com objetivo de negócio,

  queries substituídas e dicionário de colunas de cada view

Backend:
- Criadas entidades read-only em model/view/ com @Entity + @Immutable mapeando diretamente para cada view do banco
- Criados repositories em repository/view/ com JpaRepository e métodos de filtro por situação, cliente e categoria